### PR TITLE
Define `Base.axes1(S::Base.Slice{<:BlockedOneTo})`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -678,6 +678,7 @@ Base.summary(io::IO, a::AbstractBlockedUnitRange) =  _block_summary(io, a)
 ###
 
 Base.axes(S::Base.Slice{<:BlockedOneTo}) = (S.indices,)
+Base.axes1(S::Base.Slice{<:BlockedOneTo}) = S.indices
 Base.unsafe_indices(S::Base.Slice{<:BlockedOneTo}) = (S.indices,)
 blockaxes(S::Base.Slice) = blockaxes(S.indices)
 @propagate_inbounds getindex(S::Base.Slice, b::Block{1}) = S.indices[b]

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -713,7 +713,8 @@ end
         @test blockaxes(S) == blockaxes(b)
         @test S[Block(2)] == 2:3
         @test S[Block.(1:2)] == 1:3
-        @test axes(S) == axes(b)
+        @test axes(S) ≡ axes(b) ≡ (b,)
+        @test Base.axes1(S) ≡ b
 
 
         bs = BlockSlice(Block.(1:3), 1:6)


### PR DESCRIPTION
Define `Base.axes1(S::Base.Slice{<:BlockedOneTo}) = S.indices`, analogous to the definitions [`Base.axes(S::Base.Slice{<:BlockedOneTo})`](https://github.com/JuliaArrays/BlockArrays.jl/blob/90ddfa96fb0ade3da4f67ac285fcb340350c19c6/src/blockaxis.jl#L680) and [`Base.axes1(S::Slice{<:Base.OneTo})`](https://github.com/JuliaLang/julia/blob/cd446800a189704062bbd58970f1cff4fbc52fc1/base/indices.jl#L391).